### PR TITLE
Fix for other numerals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,7 +308,7 @@ impl Parse for NumberParser {
     fn parse<'a>(&mut self, input: &'a str) -> Result<(Self::Output, &'a str), ParseError> {
         let numbers = input
             .chars()
-            .take_while(|c| c.is_numeric())
+            .take_while(|c| c.is_digit(10))
             .collect::<String>();
 
         let len = numbers.len();
@@ -516,6 +516,12 @@ mod test {
             parse(number(), "a"),
             Err(ParseError::Msg("Expected number but got \"a\"".to_string()))
         );
+    }
+
+    #[test]
+    fn parse_number_persian_digit() {
+        let parsed = parse(number(), "۳");
+        assert_eq!(parsed, Err(ParseError::Msg("Expected number but got \"۳\"".to_string())));
     }
 
     #[test]


### PR DESCRIPTION
The [`is_numeric`](file:///home/lau/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/share/doc/rust/html/std/primitive.char.html#method.is_numeric) method for character returns true for characters other than 0-9. The current implementation crashes with ie. '۳' as `is_numeric` returns true, but `numbers.parse::<i32>().unwrap()` panics.